### PR TITLE
Ensure Port identifiers are lowercase

### DIFF
--- a/.github/workflows/port-create-service.yml
+++ b/.github/workflows/port-create-service.yml
@@ -50,6 +50,9 @@ jobs:
           organizationName: ${{ env.ORG_NAME }}
           createPortEntity: false
 
+      - name: Set service name lowercase
+        run: echo "SERVICE_NAME_LC=${{ inputs.service_name }}" | tr '[:upper:]' '[:lower:]' >> $GITHUB_ENV
+
 
       - name: Create Service in Port with Repository Relation
         uses: port-labs/port-github-action@v1
@@ -58,7 +61,7 @@ jobs:
           clientSecret: ${{ secrets.PORT_CLIENT_SECRET }}
           baseUrl: https://api.getport.io
           operation: UPSERT
-          identifier: "${{ inputs.service_name }}_service"
+          identifier: "${{ env.SERVICE_NAME_LC }}_service"
           title: "${{ inputs.service_name }} Service"
           blueprint: "service"
           relations: |

--- a/terraform/azure-storage-account/main.tf
+++ b/terraform/azure-storage-account/main.tf
@@ -36,7 +36,7 @@ resource "azurerm_storage_account" "storage_account" {
 
 resource "port_entity" "azure_storage_account" {
   count      = length(azurerm_storage_account.storage_account) > 0 ? 1 : 0
-  identifier = var.storage_account_name
+  identifier = lower(var.storage_account_name)
   title      = var.storage_account_name
   blueprint  = "azureStorageAccount"
   run_id     = var.port_run_id


### PR DESCRIPTION
## Summary
- normalize service name to lowercase before upserting to Port
- enforce lowercase Port identifiers for Terraform-managed storage accounts

## Testing
- `actionlint .github/workflows/port-create-service.yml`
- `terraform fmt -check`
- `terraform validate` *(fails: Missing required provider for azurerm and port-labs/port-labs)*

------
https://chatgpt.com/codex/tasks/task_e_68a061eab7fc8330bcb9591067254797